### PR TITLE
feat: add clear orders functionality for developer mode

### DIFF
--- a/services/server/Dockerfile.dev
+++ b/services/server/Dockerfile.dev
@@ -18,7 +18,6 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 COPY --chown=ryanzola . .
-COPY wsgi-entrypoint.sh .
 RUN dos2unix migrate-script.sh
 COPY --chown=ryanzola docker-start.sh .
 RUN chmod 777 /app migrate-script.sh docker-start.sh

--- a/services/server/order/urls.py
+++ b/services/server/order/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path('past_orders/', views.past_orders, name='past_orders'),
     path('start_session/', views.start_session, name='start_session'),
     path('end_session/', views.end_session, name='end_session'),
+    path('clear_queued_orders/', views.clear_queued_orders, name='clear_queued_orders'),
 ]

--- a/services/server/order/views.py
+++ b/services/server/order/views.py
@@ -413,3 +413,21 @@ def end_session(request):
     except Exception as e:
         logger.error(f"Unexpected error in end_session: {e}", exc_info=True)
         return Response({"error": str(e)}, status=500)
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def clear_queued_orders(request):
+    try:
+        # Check if DEBUG is True
+        if not settings.DEBUG:
+            return JsonResponse({'error': 'This endpoint is only available in developer mode.'}, status=403)
+
+        # Delete all orders with status 'queued'
+        deleted_count, _ = Order.objects.filter(status='queued').delete()
+
+        return JsonResponse({'message': f'Successfully cleared {deleted_count} queued orders.'}, status=200)
+
+    except Exception as e:
+        logger.error(f"Unexpected error in clear_queued_orders: {e}", exc_info=True)
+        return JsonResponse({"error": str(e)}, status=500)

--- a/services/server/wsgi-entrypoint.sh
+++ b/services/server/wsgi-entrypoint.sh
@@ -1,3 +1,0 @@
-python manage.py collectstatic --noinput
-python manage.py migrate
-gunicron pizzaserver.wsgi --bind 0.0.0.0:8005 --workers 4 --threads 4

--- a/services/web/package.json
+++ b/services/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "proxy": "http://localhost:8000",
   "engines": {
-    "node": "16.x"
+    "node": "21.x"
   },
   "scripts": {
     "dev": "vite",

--- a/services/web/src/store/orders.js
+++ b/services/web/src/store/orders.js
@@ -39,6 +39,9 @@ const mutations = {
       if (order) order.user = state.user;
     });
   },
+  REMOVE_QUEUED_ORDERS(state) {
+    state.orders = state.orders.filter(order => order.status !== 'queued');
+  },
 }
 
 const actions = {
@@ -47,13 +50,13 @@ const actions = {
     const filteredOrders = state.selected_orders.filter(order => ['pending', 'en_route'].includes(order.status));
     const multiplier = 1.1;
 
-    const additionalWaitTime = filteredOrders.length > 6 
-      ? baseWaitTime * (filteredOrders.length - 6) * multiplier 
+    const additionalWaitTime = filteredOrders.length > 6
+      ? baseWaitTime * (filteredOrders.length - 6) * multiplier
       : 0;
 
     const totalWaitTime = baseWaitTime + additionalWaitTime;
     const cancellationTime = totalWaitTime + baseWaitTime;
-    
+
     state.waitTime = totalWaitTime;
 
     const playerLatitude = rootState.location.player.latitude;
@@ -77,7 +80,7 @@ const actions = {
         }
       }
 
-      if (!newStatus && timeSinceOrderPlaced > cancellationTime) {        
+      if (!newStatus && timeSinceOrderPlaced > cancellationTime) {
         newStatus = 'cancelled';
       }
 
@@ -90,7 +93,7 @@ const actions = {
           });
 
           commit('UPDATE_ORDER_STATUS', { orderId: order.id, status: newStatus });
-        
+
         } catch (error) {
           console.error('Failed to update order status:', error);
           throw error; // or handle it differently if needed
@@ -150,6 +153,15 @@ const actions = {
     } catch (error) {
       console.error('Failed to fetch selected orders:', error)
       throw error
+    }
+  },
+  async clearQueuedOrders({ commit }) {
+    try {
+      await axios.post('order/clear_queued_orders/');
+      commit('REMOVE_QUEUED_ORDERS');
+    } catch (error) {
+      console.error('Error clearing queued orders:', error);
+      throw error;
     }
   }
 }

--- a/services/web/src/views/Home.vue
+++ b/services/web/src/views/Home.vue
@@ -36,7 +36,10 @@
 
 
   <button v-if="isNearRestaurantDepot" class="order-btn" @click="() => {}">Restock Pizzeria</button>
-  <button v-else-if="selected.length === 0 && $store.state.debug_mode" class="order-btn" @click="getNewOrder">Get New Order</button>
+  <div v-else-if="selected.length === 0 && $store.state.debug_mode" class="flex border-t border-gray-500">
+    <button class="order-btn" @click="getNewOrder">Get New Order</button>
+    <button class="order-btn" @click="clearQueuedOrders">Clear Orders</button>
+  </div>
   <button v-else-if="selected.length > 0" class="order-btn" @click="setDeliveries">
     Take Deliveries
     <ChevronDoubleRightIcon class="absolute right-4 top-1/2 transform translate-y-[-50%] w-6 h-6" />
@@ -109,7 +112,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions('orders', ['fetchNewOrder', 'fetchOrders', 'attachUserToOrders']),
+    ...mapActions('orders', ['fetchNewOrder', 'fetchOrders', 'attachUserToOrders', 'clearQueuedOrders']),
     ...mapActions(['start_session', 'end_session']),
     latestOrderTimestampISO() {
       if (!this.orders || this.orders.length === 0) return undefined;


### PR DESCRIPTION
This pull request introduces a new developer-mode feature to clear all queued orders, along with related backend and frontend changes. It also updates the Node.js version for the web service and makes minor Dockerfile and script adjustments.

**Developer-mode "Clear Queued Orders" Feature:**

_Backend:_
* Added a new API endpoint `clear_queued_orders` in `order/views.py` that deletes all orders with status `'queued'` when in developer mode (DEBUG). This is only accessible to authenticated users and returns the number of deleted orders. (`order/views.py`, `order/urls.py`) [[1]](diffhunk://#diff-44138cb50a06053bef33a5c47fad05f089eb10c7becc23bb3bd848a7540f9047R416-R433) [[2]](diffhunk://#diff-8ad976bde96db087e288325e04d90470f2b436a65eb44dc0d12f1660e12a6519R13)
* The endpoint is only available if `settings.DEBUG` is `True`, preventing accidental use in production.

_Frontend:_
* Added a new Vuex mutation (`REMOVE_QUEUED_ORDERS`) and action (`clearQueuedOrders`) to remove queued orders from state and call the backend endpoint. (`src/store/orders.js`) [[1]](diffhunk://#diff-7fa93cdcf3010c91f18022f11efb5d257905cb98882089b22d3b92daa4a52d54R42-R44) [[2]](diffhunk://#diff-7fa93cdcf3010c91f18022f11efb5d257905cb98882089b22d3b92daa4a52d54R157-R165)
* Updated the Home page UI to show a "Clear Orders" button in debug mode, which triggers the clear action. (`src/views/Home.vue`) [[1]](diffhunk://#diff-3651cd98dbea0a0bf57974ecaa4e1daba71156d3ea51cdc934da4e1ae8534ec0L39-R42) [[2]](diffhunk://#diff-3651cd98dbea0a0bf57974ecaa4e1daba71156d3ea51cdc934da4e1ae8534ec0L112-R115)

**Other changes:**

_Environment and scripts:_
* Updated the Node.js engine version requirement for the web service from `16.x` to `21.x` in `package.json`.
* Removed the unused `wsgi-entrypoint.sh` script from the Docker development build and deleted its contents. (`Dockerfile.dev`, `wsgi-entrypoint.sh`) [[1]](diffhunk://#diff-c32c66c95acf9d4422f7083592295ff699a9562beb2e7ab83b5c1a739d95b201L21) [[2]](diffhunk://#diff-fa018a1b5d9946f38f8956beffd6766438bf013e996a62ad004236b268855d7eL1-L3)