### PR TITLE
feat: Automatically create game sessions and trigger order status updates directly from geolocation changes.

### DIFF
--- a/services/web/src/App.vue
+++ b/services/web/src/App.vue
@@ -20,11 +20,9 @@ export default {
   },
   async mounted() {
     this.$store.dispatch('location/startGeolocation');
-    this.$store.dispatch('location/startInterval');
   },
   beforeDestroy() {
     this.$store.dispatch('location/stopGeolocation');
-    this.$store.dispatch('location/stopInterval');
   },
 };
 </script>

--- a/services/web/src/store/location.js
+++ b/services/web/src/store/location.js
@@ -21,7 +21,6 @@ const state = {
   locationAvailable: false,
   watcher: null,
   thresholdDistance: 100,
-  intervalID: null,
 };
 
 const mutations = {
@@ -38,9 +37,6 @@ const mutations = {
   setLastVisited(state, lastVisited) {
     state.lastVisited = lastVisited;
   },
-  setIntervalID(state, intervalID) {
-    state.intervalID = intervalID;
-  },
 };
 
 const actions = {
@@ -53,6 +49,9 @@ const actions = {
             longitude: position.coords.longitude
           });
           commit('setLocationAvailable', true);
+
+          // Trigger the distance check directly when geolocation changes
+          dispatch('orders/checkAndUpdateOrderStatus', null, { root: true });
         },
         error => {
           console.error(error.message);
@@ -60,7 +59,8 @@ const actions = {
         },
         {
           enableHighAccuracy: true,
-          timeout: 1000,
+          timeout: 5000,
+          maximumAge: 10000,
         }
       );
       commit('setWatcher', watcher);
@@ -72,18 +72,6 @@ const actions = {
     if (state.watcher) {
       navigator.geolocation.clearWatch(state.watcher);
       commit('setWatcher', null);
-    }
-  },
-  startInterval({ commit, dispatch }) {
-    const intervalID = setInterval(() => {
-      dispatch('orders/checkAndUpdateOrderStatus', null, { root: true });
-    }, 500);
-    commit('setIntervalID', intervalID);
-  },
-  stopInterval({ state, commit }) {
-    if (state.intervalID) {
-      clearInterval(state.intervalID);
-      commit('setIntervalID', null);
     }
   },
 };

--- a/services/web/src/store/orders.js
+++ b/services/web/src/store/orders.js
@@ -67,12 +67,12 @@ const actions = {
       let newStatus = null;
       const timeSinceOrderPlaced = Date.now() - new Date(order.date_placed).getTime();
 
-      if (order.refData?.latitude && order.refData?.longitude) {
+      if (order.latitude && order.longitude) {
         const distanceToOrder = getDistanceFromLatLonInM(
           playerLatitude,
           playerLongitude,
-          order.refData?.latitude,
-          order.refData?.longitude
+          order.latitude,
+          order.longitude
         );
 
         if (distanceToOrder <= rootState.location.thresholdDistance) {

--- a/services/web/src/views/Home.vue
+++ b/services/web/src/views/Home.vue
@@ -21,11 +21,11 @@
     <DebugLocation />
     <div class="p-4">
       <h1 class="text-2xl font-bold">Orders</h1>
-      <p :class="{ 'opacity-0': isNearPizzeria }" :aria-hidden="isNearPizzeria">Return to the pizzeria to get more orders</p>
+      <p :class="{ 'opacity-0': isNearPizzeria && !$store.state.debug_mode }" :aria-hidden="isNearPizzeria && !$store.state.debug_mode">Return to the pizzeria to get more orders</p>
     </div>
   </div>
 
-  <ul :class="['orders', { 'transform opacity-50': !isNearPizzeria }]">
+  <ul :class="['orders', { 'transform opacity-50': !isNearPizzeria && !$store.state.debug_mode }]">
     <Order v-for="order in pendingOrders" :key="order.id" :order="order" @change="toggleOrderSelection" />
   </ul>
 


### PR DESCRIPTION
This pull request introduces significant improvements to session handling on the backend and optimizes geolocation and order status updates on the frontend. The main changes include automatic session creation and spawner loop initialization when attaching users to orders, removal of interval-based location polling in favor of event-driven updates, and enhanced debugging controls for order visibility.

Backend session management improvements:

* Updated `attach_user_to_orders` in `order/views.py` to automatically end any lingering active sessions, create a new session if none exists, and start the spawner loop thread for new sessions. This ensures users always have a valid session and background processing is reliably triggered.

Frontend geolocation and order status update optimizations:

* Removed interval-based polling for order status updates in `App.vue` and `store/location.js`, switching to direct triggering of `orders/checkAndUpdateOrderStatus` whenever geolocation changes. This reduces unnecessary polling and improves responsiveness. [[1]](diffhunk://#diff-6e9be0b544eeff4b6385b2e656080d7cfa5f3c32fc4e5099b2c47e8652f2bba2L23-L27) [[2]](diffhunk://#diff-7b5541ae005c94dcde9825e33a8e9970ecdb4845018922ca148ca571c0bf200eL77-L88) [[3]](diffhunk://#diff-7b5541ae005c94dcde9825e33a8e9970ecdb4845018922ca148ca571c0bf200eL41-L43) [[4]](diffhunk://#diff-7b5541ae005c94dcde9825e33a8e9970ecdb4845018922ca148ca571c0bf200eL24)
* Increased geolocation timeout and added `maximumAge` for improved accuracy and performance.

Order data handling improvements:

* Updated `store/orders.js` to reference `order.latitude` and `order.longitude` directly, simplifying distance calculations and removing dependency on nested `refData`.

Debugging and UI enhancements:

* Improved order list and message visibility in `Home.vue` by factoring in `debug_mode`, allowing developers to bypass location restrictions for testing.