### PR TITLE
build: update server Python dependencies

### DIFF
--- a/services/server/requirements.txt
+++ b/services/server/requirements.txt
@@ -38,7 +38,7 @@ idna==3.4
 multidict==6.0.4
 oauthlib==3.2.2
 openai==1.35.7
-packaging==23.2
+packaging>=24.0
 postgrest==0.16.8
 proto-plus==1.22.3
 protobuf==4.25.1


### PR DESCRIPTION
This pull request updates a dependency version constraint in the `services/server/requirements.txt` file to ensure compatibility with newer versions.

Dependency version update:

* Changed the `packaging` library requirement from an exact version (`23.2`) to a minimum version (`>=24.0`), allowing use of newer releases.